### PR TITLE
Fix the `insta_science.ensure_installed` API.

### DIFF
--- a/python/CHANGES.md
+++ b/python/CHANGES.md
@@ -1,5 +1,9 @@
 # insta-science
 
+## 0.2.1
+
+Fix the `insta_science.ensure_installed` API to not exit on error.
+
 ## 0.2.0
 
 Expose the `insta_science.ensure_installed` API for programmatic access

--- a/python/insta_science/_internal/a_scie.py
+++ b/python/insta_science/_internal/a_scie.py
@@ -45,11 +45,9 @@ def _load_project_release(
     return _LoadResult(path=path, binary_name=qualified_binary_name)
 
 
-def science(
-    specification: Science | None = None, platform: Platform = Platform.current()
-) -> PurePath:
-    version = specification.version if specification else None
-    fingerprint = specification.digest if specification and specification.digest else None
+def science(spec: Science | None = None, platform: Platform = Platform.current()) -> PurePath:
+    version = spec.version if spec else None
+    fingerprint = spec.digest if spec and spec.digest else None
     return _load_project_release(
         project_name="lift",
         binary_name="science-fat",

--- a/python/insta_science/_internal/hashing.py
+++ b/python/insta_science/_internal/hashing.py
@@ -20,6 +20,10 @@ class Fingerprint(str):
 
 @dataclass(frozen=True)
 class Digest:
+    @classmethod
+    def spec(cls, size: int, fingerprint: str) -> Digest:
+        return cls(size=size, fingerprint=Fingerprint(fingerprint))
+
     size: int
     fingerprint: Fingerprint
 

--- a/python/insta_science/_internal/model.py
+++ b/python/insta_science/_internal/model.py
@@ -14,6 +14,10 @@ from .hashing import Digest
 
 @dataclass(frozen=True)
 class Science:
+    @classmethod
+    def spec(cls, version: str, digest: Digest | None = None) -> Science:
+        return cls(version=Version(version), digest=digest)
+
     version: Version | None = None
     digest: Digest | None = None
 

--- a/python/insta_science/_internal/platform.py
+++ b/python/insta_science/_internal/platform.py
@@ -57,8 +57,12 @@ class Platform(Enum):
         )
 
     @property
+    def is_windows(self) -> bool:
+        return self in (self.Windows_aarch64, self.Windows_x86_64)
+
+    @property
     def extension(self) -> str:
-        return ".exe" if self in (self.Windows_aarch64, self.Windows_x86_64) else ""
+        return ".exe" if self.is_windows else ""
 
     def binary_name(self, binary_name: str) -> str:
         return f"{binary_name}{self.extension}"

--- a/python/insta_science/shim.py
+++ b/python/insta_science/shim.py
@@ -23,7 +23,7 @@ def main() -> NoReturn:
 
     argv = [str(science_exe), *sys.argv[1:]]
     try:
-        if Platform.current() in (Platform.Windows_aarch64, Platform.Windows_x86_64):
+        if Platform.current().is_windows:
             sys.exit(subprocess.run(argv).returncode)
         else:
             os.execv(science_exe, argv)

--- a/python/insta_science/version.py
+++ b/python/insta_science/version.py
@@ -1,4 +1,4 @@
 # Copyright 2024 Science project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -109,13 +109,18 @@ check-fmt = ["ruff", "format", "--diff"]
 lint = ["ruff", "check", "--fix"]
 check-lint = ["ruff", "check"]
 
-type-check = ["mypy", "insta_science", "scripts"]
-type-check-39 = ["mypy", "--python-version", "3.9", "insta_science", "scripts"]
-type-check-313 = ["mypy", "--python-version", "3.13", "insta_science", "scripts"]
+type-check = ["mypy", "insta_science", "scripts", "test-support", "tests"]
+type-check-39 = [
+    "mypy", "--python-version", "3.9", "insta_science", "scripts", "test-support", "tests"
+]
+type-check-313 = [
+    "mypy", "--python-version", "3.13", "insta_science", "scripts", "test-support", "tests"
+]
 
 release = ["python", "scripts/release.py"]
 
 [tool.dev-cmd.commands.test]
+env = {"PYTHONPATH" = "test-support"}
 args = ["pytest", "-n", "auto"]
 accepts-extra-args = true
 

--- a/python/test-support/testing/__init__.py
+++ b/python/test-support/testing/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2024 Science project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+from pathlib import PurePath
+
+from insta_science import Platform
+
+
+def is_exe(path: PurePath) -> bool:
+    if not os.path.isfile(path):
+        return False
+    if Platform.current().is_windows:
+        return ".exe" == path.suffix
+    return os.access(path, os.R_OK | os.X_OK)

--- a/python/test-support/testing/__init__.py
+++ b/python/test-support/testing/__init__.py
@@ -11,5 +11,5 @@ def is_exe(path: PurePath) -> bool:
     if not os.path.isfile(path):
         return False
     if Platform.current().is_windows:
-        return ".exe" == path.suffix
+        return True
     return os.access(path, os.R_OK | os.X_OK)

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,73 @@
+# Copyright 2024 Science project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pathlib import Path
+
+import pytest
+from pytest import MonkeyPatch
+
+from insta_science import Platform
+
+
+@pytest.fixture
+def platform() -> Platform:
+    return Platform.current()
+
+
+@pytest.fixture
+def pyproject_toml(monkeypatch: MonkeyPatch, tmp_path: Path) -> Path:
+    project_dir = tmp_path / "project"
+    project_dir.mkdir(parents=True)
+    pyproject_toml = project_dir / "pyproject.toml"
+    monkeypatch.setenv("INSTA_SCIENCE_CONFIG", str(pyproject_toml))
+    return pyproject_toml
+
+
+@pytest.fixture
+def expected_v0_9_0_url(platform) -> str:
+    expected_binary_name = platform.qualified_binary_name("science-fat")
+    return f"https://github.com/a-scie/lift/releases/download/v0.9.0/{expected_binary_name}"
+
+
+@pytest.fixture
+def expected_v0_9_0_size(platform) -> int:
+    if platform is Platform.Linux_aarch64:
+        return 21092144
+    if platform is Platform.Linux_armv7l:
+        return 20570562
+    if platform is Platform.Linux_x86_64:
+        return 24784994
+
+    if platform is Platform.Macos_aarch64:
+        return 18619230
+    if platform is Platform.Macos_aarch64:
+        return 19098999
+
+    if platform is Platform.Windows_aarch64:
+        return 24447228
+    if platform is Platform.Windows_x86_64:
+        return 24615918
+
+    pytest.skip(f"Unsupported platform for science v0.9.0: {platform}")
+
+
+@pytest.fixture
+def expected_v0_9_0_fingerprint(platform) -> str:
+    if platform is Platform.Linux_aarch64:
+        return "e9b1ad6731ed22d528465fd1464a6183b43e7a7aa54211309bbe9fc8894e85ac"
+    if platform is Platform.Linux_armv7l:
+        return "1935c90c527d13ec0c46db4718a0d5f9050d264d08ba222798b8f47836476b7d"
+    if platform is Platform.Linux_x86_64:
+        return "37ce3ed19f558e2c18d3339a4a5ee40de61a218b7a42408451695717519c4160"
+
+    if platform is Platform.Macos_aarch64:
+        return "e6fffeb0e8abd7e16af317aad97cb9852b18f0302f36a9022f3e76f3c2cca1ef"
+    if platform is Platform.Macos_aarch64:
+        return "640487cb1402d5edd6f86c9acaad6b18d1ddd553375db50d06480cccf4fccd7e"
+
+    if platform is Platform.Windows_aarch64:
+        return "e0f1b08c4701681b726315f8f1b86a4d7580240abfc1c0a7c6a2ba024da4d558"
+    if platform is Platform.Windows_x86_64:
+        return "722030eb6bb5f9510acd5b737eda2b735918ee28df4b93d297a9dfa54fc4d6fb"
+
+    pytest.skip(f"Unsupported platform for science v0.9.0: {platform}")

--- a/python/tests/test_api.py
+++ b/python/tests/test_api.py
@@ -1,0 +1,63 @@
+# Copyright 2024 Science project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import subprocess
+from pathlib import Path, PurePath
+from textwrap import dedent
+
+from packaging.version import Version
+from testing import is_exe
+
+from insta_science import Digest, Science, ensure_installed
+
+
+def get_science_exe_version(science_exe: PurePath) -> Version:
+    return Version(
+        subprocess.run(
+            args=[science_exe, "-V"], text=True, stdout=subprocess.PIPE, check=True
+        ).stdout.strip()
+    )
+
+
+def assert_science_exe_version(science_exe: PurePath, expected_version: str) -> None:
+    assert Version(expected_version) == get_science_exe_version(science_exe)
+
+
+def test_simple():
+    science_exe = ensure_installed()
+    assert is_exe(science_exe)
+    assert get_science_exe_version(science_exe) >= Version("0.10.0"), (
+        "By default ensure_installed should fetch the latest science version, which was 0.10.0 at "
+        "the time this test was 1st introduced."
+    )
+
+
+def test_pyproject_toml_default(pyproject_toml: Path):
+    pyproject_toml.write_text(
+        dedent(
+            """\
+            [tool.insta-science.science]
+            version = "0.8.2"
+            """
+        )
+    )
+    science_exe = ensure_installed()
+    assert is_exe(science_exe)
+    assert_science_exe_version(science_exe, "0.8.2")
+
+
+def test_version_spec():
+    science_exe = ensure_installed(spec=Science.spec(version="0.9.0"))
+    assert is_exe(science_exe)
+    assert_science_exe_version(science_exe, "0.9.0")
+
+
+def test_digest_spec(expected_v0_9_0_size: int, expected_v0_9_0_fingerprint: str):
+    science_exe = ensure_installed(
+        spec=Science.spec(
+            version="0.9.0",
+            digest=Digest.spec(size=expected_v0_9_0_size, fingerprint=expected_v0_9_0_fingerprint),
+        )
+    )
+    assert is_exe(science_exe)
+    assert_science_exe_version(science_exe, "0.9.0")

--- a/python/tests/test_shim.py
+++ b/python/tests/test_shim.py
@@ -5,31 +5,35 @@ import subprocess
 from pathlib import Path
 from textwrap import dedent
 
-import _pytest
 import pytest
 from packaging.version import Version
+from pytest import MonkeyPatch
 
-from insta_science import Platform
+
+def get_science_exe_version_via_insta_science() -> Version:
+    return Version(
+        subprocess.run(
+            args=["insta-science", "-V"], text=True, stdout=subprocess.PIPE, check=True
+        ).stdout.strip()
+    )
+
+
+def assert_science_exe_version_via_insta_science(expected_version: str) -> None:
+    assert Version(expected_version) == get_science_exe_version_via_insta_science()
 
 
 def test_self() -> None:
-    subprocess.run(args=["insta-science", "-V"], check=True)
+    assert get_science_exe_version_via_insta_science() >= Version("0.10.0"), (
+        "By default insta-science should fetch the latest science version, which was 0.10.0 at "
+        "the time this test was 1st introduced."
+    )
 
 
 @pytest.fixture(autouse=True)
-def cache_dir(monkeypatch: _pytest.monkeypatch, tmp_path: Path) -> Path:
+def cache_dir(monkeypatch: MonkeyPatch, tmp_path: Path) -> Path:
     cache_dir = tmp_path / "cache"
     monkeypatch.setenv("INSTA_SCIENCE_CACHE", str(cache_dir))
     return cache_dir
-
-
-@pytest.fixture
-def pyproject_toml(monkeypatch: _pytest.monkeypatch, tmp_path: Path) -> Path:
-    project_dir = tmp_path / "project"
-    project_dir.mkdir(parents=True)
-    pyproject_toml = project_dir / "pyproject.toml"
-    monkeypatch.setenv("INSTA_SCIENCE_CONFIG", str(pyproject_toml))
-    return pyproject_toml
 
 
 def test_version(pyproject_toml: Path) -> None:
@@ -41,66 +45,7 @@ def test_version(pyproject_toml: Path) -> None:
             """
         )
     )
-    assert Version("0.9.0") == Version(
-        subprocess.run(
-            args=["insta-science", "-V"], text=True, stdout=subprocess.PIPE, check=True
-        ).stdout.strip()
-    )
-
-
-@pytest.fixture
-def platform() -> Platform:
-    return Platform.current()
-
-
-@pytest.fixture
-def expected_v0_9_0_url(platform) -> str:
-    expected_binary_name = platform.qualified_binary_name("science-fat")
-    return f"https://github.com/a-scie/lift/releases/download/v0.9.0/{expected_binary_name}"
-
-
-@pytest.fixture
-def expected_v0_9_0_size(platform) -> int:
-    if platform is Platform.Linux_aarch64:
-        return 21092144
-    if platform is Platform.Linux_armv7l:
-        return 20570562
-    if platform is Platform.Linux_x86_64:
-        return 24784994
-
-    if platform is Platform.Macos_aarch64:
-        return 18619230
-    if platform is Platform.Macos_aarch64:
-        return 19098999
-
-    if platform is Platform.Windows_aarch64:
-        return 24447228
-    if platform is Platform.Windows_x86_64:
-        return 24615918
-
-    pytest.skip(f"Unsupported platform for science v0.9.0: {platform}")
-
-
-@pytest.fixture
-def expected_v0_9_0_fingerprint(platform) -> str:
-    if platform is Platform.Linux_aarch64:
-        return "e9b1ad6731ed22d528465fd1464a6183b43e7a7aa54211309bbe9fc8894e85ac"
-    if platform is Platform.Linux_armv7l:
-        return "1935c90c527d13ec0c46db4718a0d5f9050d264d08ba222798b8f47836476b7d"
-    if platform is Platform.Linux_x86_64:
-        return "37ce3ed19f558e2c18d3339a4a5ee40de61a218b7a42408451695717519c4160"
-
-    if platform is Platform.Macos_aarch64:
-        return "e6fffeb0e8abd7e16af317aad97cb9852b18f0302f36a9022f3e76f3c2cca1ef"
-    if platform is Platform.Macos_aarch64:
-        return "640487cb1402d5edd6f86c9acaad6b18d1ddd553375db50d06480cccf4fccd7e"
-
-    if platform is Platform.Windows_aarch64:
-        return "e0f1b08c4701681b726315f8f1b86a4d7580240abfc1c0a7c6a2ba024da4d558"
-    if platform is Platform.Windows_x86_64:
-        return "722030eb6bb5f9510acd5b737eda2b735918ee28df4b93d297a9dfa54fc4d6fb"
-
-    pytest.skip(f"Unsupported platform for science v0.9.0: {platform}")
+    assert_science_exe_version_via_insta_science("0.9.0")
 
 
 def test_digest(
@@ -117,11 +62,7 @@ def test_digest(
             """
         )
     )
-    assert Version("0.9.0") == Version(
-        subprocess.run(
-            args=["insta-science", "-V"], text=True, stdout=subprocess.PIPE, check=True
-        ).stdout.strip()
-    )
+    assert_science_exe_version_via_insta_science("0.9.0")
 
 
 def test_size_mismatch(

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -165,6 +165,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "dev-cmd" },
+    { name = "marko" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-xdist" },
@@ -188,12 +189,22 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "dev-cmd" },
+    { name = "marko" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "types-appdirs" },
     { name = "types-tqdm" },
+]
+
+[[package]]
+name = "marko"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/38/6ea5d8600b94432656c669816a479580d9f1c49ef6b426282f4ba261ae9b/marko-2.1.2.tar.gz", hash = "sha256:a9170006b879376e6845c91b1ae3dce2992772954b99b70175ff888537186011", size = 142593 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/9b/3dbfbe6ee255b1c37a37e2a6046adb2e77763a020591dae63e5005a2c8d7/marko-2.1.2-py3-none-any.whl", hash = "sha256:c14aa7a77468aaaf53cf056dcd3d32398b9df4c3fb81f5e120dd37cbb9f8c859", size = 42089 },
 ]
 
 [[package]]


### PR DESCRIPTION
Previously a partial re-factor left shim code in place that would exit
the process on error. Now the API is fixed to raise documented
exceptions instead.