### PR TITLE
Fix cache prune for foreign science binaries.

### DIFF
--- a/python/CHANGES.md
+++ b/python/CHANGES.md
@@ -1,5 +1,9 @@
 # insta-science
 
+## 0.6.1
+
+Fix cache pruning for foreign science binaries downloaded via `insta-science-util download`.
+
 ## 0.6.0
 
 Add support for science musl releases.

--- a/python/insta_science/_internal/model.py
+++ b/python/insta_science/_internal/model.py
@@ -31,7 +31,7 @@ class ScienceExe:
         try:
             version = Version(
                 subprocess.run(
-                    args=[self.path, "-V"], text=True, stdout=subprocess.PIPE
+                    args=[self.path, "-V"], capture_output=True, text=True, check=True
                 ).stdout.strip()
             )
         except CalledProcessError as e:

--- a/python/insta_science/_internal/version.py
+++ b/python/insta_science/_internal/version.py
@@ -1,4 +1,4 @@
 # Copyright 2024 Science project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"


### PR DESCRIPTION
These foreign binaries will be present in the cache after a download
that includes foreign platforms.